### PR TITLE
Fix typos and minor issues found during code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Swift installation file
+swift-*.tar.gz

--- a/Sources/Camera/Camera.swift
+++ b/Sources/Camera/Camera.swift
@@ -195,7 +195,7 @@ extension Camera: CameraProtocol {
         try await changeDevice(device: device)
     }
 
-    func swicthPosition() async throws {
+    func switchPosition() async throws {
         config.switchPosition()
         guard let device = config.getDefaultCamera() else {
             throw CameraError.cameraUnavailable

--- a/Sources/Camera/CameraProtocol.swift
+++ b/Sources/Camera/CameraProtocol.swift
@@ -23,7 +23,7 @@ protocol CameraProtocol: Actor {
     func changeCodec(_ codec: VideoCodecType)
     func changeFlashMode(_ flashMode: CameraFlashMode)
     func changeZoom(_ factor: Float) throws
-    func swicthPosition() async throws
+    func switchPosition() async throws
     func end() async
     func createStreams()
 }

--- a/Sources/Camera/CameraView.swift
+++ b/Sources/Camera/CameraView.swift
@@ -239,7 +239,6 @@ extension CameraView {
 
     struct DeviceSettingsView: View {
         @StateObject var model: CameraModel
-//        @Binding var zoom: Double
         var body: some View {
             List {
                 Section(header: Text("Devices").bold()) {
@@ -302,7 +301,7 @@ extension CameraView {
 
         var body: some View {
             List {
-                Section(header: Text("Formats").bold()) {
+                Section(header: Text("Flash Modes").bold()) {
                     ForEach(model.flashModes, id: \.self) { flashMode in
                         Button(action: { model.selectFlashMode(flashMode) }) {
                             HStack {

--- a/Sources/Camera/Image+extensions.swift
+++ b/Sources/Camera/Image+extensions.swift
@@ -12,6 +12,8 @@ extension Image.Orientation {
             case .leftMirrored: self = .leftMirrored
             case .right: self = .right
             case .rightMirrored: self = .rightMirrored
+        @unknown default:
+            self = .up
         }
     }
 

--- a/Sources/Camera/MockCamera.swift
+++ b/Sources/Camera/MockCamera.swift
@@ -76,7 +76,7 @@ actor MockCamera: CameraProtocol {
         }
     }
 
-    func switchFlash(_ value: CameraFlashMode) {
+    func changeFlashMode(_ value: CameraFlashMode) {
         config.flashMode = value
     }
 


### PR DESCRIPTION
This commit addresses several issues found during a manual code review:
- Corrected a typo from `swicthPosition` to `switchPosition`.
- Fixed a copy-pasted section header in the settings UI.
- Removed dead code.
- Added a missing `@unknown default` case to improve robustness.
- Corrected a function name in the mock camera to match the protocol.